### PR TITLE
Bump linter to v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: make protobuf
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: 'v2.11.4'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __debug_bin*
 .idea
+.tools/
 bin/
 *.pb.go
 *.pem

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,357 +1,217 @@
-# This code is licensed under the terms of the MIT license https://opensource.org/license/mit
-# Copyright (c) 2021 Marat Reymers
-
-## Golden config for golangci-lint v1.59.1
-#
-# This is the best config for golangci-lint based on my experience and opinion.
-# It is very strict, but not extremely strict.
-# Feel free to adapt and change it for your needs.
-
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 3m
-
-
-# This file contains only configs which differ from defaults.
-# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-linters-settings:
-  gosec:
-    excludes:
-      # Remove weak crypto warnings that are required in implementation (like ripemd)
-      - G406
-      - G507
-  staticcheck:
-    checks:
-      # Remove weak crypto warnings that are required in implementation (like ripemd)
-      - '-SA1019'
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 30
-    # The maximal average package complexity.
-    # If it's higher than 0.0 (float) the check is enabled
-    # Default: 0.0
-    package-average: 10.0
-
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
-
-  exhaustive:
-    # Program elements to check for exhaustiveness.
-    # Default: [ switch ]
-    check:
-      - switch
-      - map
-
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and their names from checks.
-    # Regular expressions must match complete canonical struct package/name/structname.
-    # Default: []
-    exclude:
-      # std libs
-      - "^net/http.Client$"
-      - "^net/http.Cookie$"
-      - "^net/http.Request$"
-      - "^net/http.Response$"
-      - "^net/http.Server$"
-      - "^net/http.Transport$"
-      - "^net/url.URL$"
-      - "^os/exec.Cmd$"
-      - "^reflect.StructField$"
-      # public libs
-      - "^github.com/Shopify/sarama.Config$"
-      - "^github.com/Shopify/sarama.ProducerMessage$"
-      - "^github.com/mitchellh/mapstructure.DecoderConfig$"
-      - "^github.com/prometheus/client_golang/.+Opts$"
-      - "^github.com/spf13/cobra.Command$"
-      - "^github.com/spf13/cobra.CompletionOptions$"
-      - "^github.com/stretchr/testify/mock.Mock$"
-      - "^github.com/testcontainers/testcontainers-go.+Request$"
-      - "^github.com/testcontainers/testcontainers-go.FromDockerfile$"
-      - "^golang.org/x/tools/go/analysis.Analyzer$"
-      - "^google.golang.org/protobuf/.+Options$"
-      - "^gopkg.in/yaml.v3.Node$"
-
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 100
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 50
-    # Ignore comments when counting lines.
-    # Default false
-    ignore-comments: true
-
-  gocognit:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
-
-  gocritic:
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:
-        # Whether to restrict checker to params only.
-        # Default: true
-        paramsOnly: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
-
-  gomodguard:
-    blocked:
-      # List of blocked modules.
-      # Default: []
-      modules:
-        - github.com/golang/protobuf:
-            recommendations:
-              - google.golang.org/protobuf
-            reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
-        - github.com/satori/go.uuid:
-            recommendations:
-              - github.com/google/uuid
-            reason: "satori's package is not maintained"
-        - github.com/gofrs/uuid:
-            recommendations:
-              - github.com/gofrs/uuid/v5
-            reason: "gofrs' package was not go module before v5"
-
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: true
-
-  inamedparam:
-    # Skips check for interface methods with only a single parameter.
-    # Default: false
-    skip-single-param: true
-
-  mnd:
-    # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Date`,
-    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
-    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
-    # Default: []
-    ignored-functions:
-      - args.Error
-      - flag.Arg
-      - flag.Duration.*
-      - flag.Float.*
-      - flag.Int.*
-      - flag.Uint.*
-      - os.Chmod
-      - os.Mkdir.*
-      - os.OpenFile
-      - os.WriteFile
-      - prometheus.ExponentialBuckets.*
-      - prometheus.LinearBuckets
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 0
-
-  nolintlint:
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: [ funlen, gocognit, lll ]
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-
-  perfsprint:
-    # Optimizes into strings concatenation.
-    # Default: true
-    strconcat: false
-
-  rowserrcheck:
-    # database/sql is always checked
-    # Default: []
-    packages:
-      - github.com/jmoiron/sqlx
-
-  sloglint:
-    # Enforce not using global loggers.
-    # Values:
-    # - "": disabled
-    # - "all": report all global loggers
-    # - "default": report only the default slog logger
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
-    # Default: ""
-    no-global: "all"
-    # Enforce using methods that accept a context.
-    # Values:
-    # - "": disabled
-    # - "all": report all contextless calls
-    # - "scope": report only if a context exists in the scope of the outermost function
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
-    # Default: ""
-    context: "scope"
-
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    ## enabled by default
-    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
-    - gosimple # specializes in simplifying a code
-    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # detects when assignments to existing variables are not used
-    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
-    - unused # checks for unused constants, variables, functions and types
-    ## disabled by default
-    - asasalint # checks for pass []any as any in variadic func(...any)
-    - asciicheck # checks that your code does not contain non-ASCII identifiers
-    - bidichk # checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - canonicalheader # checks whether net/http.Header uses canonical header
-    - copyloopvar # detects places where loop variables are copied
-    - cyclop # checks function and package cyclomatic complexity
-    - dupl # tool for code clone detection
-    - durationcheck # checks for two durations multiplied together
-    - errname # checks that sentinel errors are prefixed with the Err and errors types are suffixed with the Error
-    - errorlint # finds code that will cause problems with the errors wrapping scheme introduced in Go 1.13
-    - exhaustive # checks exhaustiveness of enum switch statements
-    - fatcontext # detects nested contexts in loops
-    - forbidigo # forbids identifiers
-    - funlen # tool for detection of long functions
-    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
-    - gochecknoglobals # checks that no global variables exist
-    - gochecknoinits # checks that no init functions are present in Go code
-    - gochecksumtype # checks exhaustiveness on Go "sum types"
-    - gocognit # computes and checks the cognitive complexity of functions
-    - goconst # finds repeated strings that could be replaced by a constant
-    - gocritic # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo # computes and checks the cyclomatic complexity of functions 
-    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
-    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
-    - goprintffuncname # checks that printf-like functions are named with f at the end
-    - gosec # inspects source code for security problems
-    - intrange # finds places where for loops could make use of an integer range
-    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
-    - makezero # finds slice declarations with non-zero initial length
-    - mirror # reports wrong mirror patterns of bytes/strings usage
-    - mnd # detects magic numbers
-    - musttag # enforces field tags in (un)marshaled structs
-    - nakedret # finds naked returns in functions greater than a specified function length
-    - nestif # reports deeply nested if statements
-    - nilerr # finds the code that returns nil even if it checks that the errors is not nil
-    - nilnil # checks that there is no simultaneous return of nil errors and an invalid value
-    - noctx # finds sending http request without context.Context
-    - nolintlint # reports ill-formed or insufficient nolint directives
-    - nonamedreturns # reports all named returns
-    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
-    - predeclared # finds code that shadows one of Go's predeclared identifiers
-    - promlinter # checks Prometheus metrics naming via promlint
-    - protogetter # reports direct reads from proto message fields when getters should be used
-    - reassign # checks that package variables are not reassigned
-    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - sloglint # ensure consistent code style when using log/slog
-    - spancheck # checks for mistakes with OpenTelemetry/Census spans
-    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
-    - stylecheck # is a replacement for golint
-    - testableexamples # checks if examples are testable (have an expected output)
-    - testifylint # checks usage of github.com/stretchr/testify
-    - testpackage # makes you use a separate _test package
-    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
-    - unconvert # removes unnecessary type conversions
-    - unparam # reports unused function parameters
-    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
-    - wastedassign # finds wasted assignment statements
-    - whitespace # detects leading and trailing whitespace
-
-    ## you may want to enable
-    #- decorder # checks declaration order and count of types, constants, variables and functions
-    #- exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
-    #- gci # controls golang package import order and makes it always deterministic
-    #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
-    #- godox # detects FIXME, TODO and other comment keywords
-    #- goheader # checks is file header matches to pattern
-    #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
-    #- interfacebloat # checks the number of methods inside an interface
-    #- ireturn # accept interfaces, return concrete types
-    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
-    #- tagalign # checks that struct tags are well aligned
-    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
-    #- wrapcheck # checks that errors returned from external packages are wrapped
-    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
-
-    ## disabled
-    #- containedctx # detects struct contained context.Context field
-    #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
-    #- depguard # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
-    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    #- dupword # [useless without config] checks for duplicate words in the source code
-    #- err113 # [too strict] checks the errors handling expressions
-    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned errors can be omitted
-    #- execinquery # [deprecated] checks query string in Query function which reads your Go src files and warning it finds
-    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
-    #- gofmt # [replaced by goimports] checks whether code was gofmt-ed
-    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
-    #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
-    #- grouper # analyzes expression groups
-    #- importas # enforces consistent import aliases
-    #- maintidx # measures the maintainability index of each function
-    #- misspell # [useless] finds commonly misspelled English words in comments
-    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
-    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
-    #- tagliatelle # checks the struct tags
-    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
-
-
-issues:
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
-  max-same-issues: 50
-
-  exclude-rules:
-    - path: "^cmd/.*"
-      linters: [ gochecknoglobals, gochecknoinits]
-    - source: "(noinspection|TODO)"
-      linters: [ godot ]
-    - source: "//noinspection"
-      linters: [ gocritic ]
-    - path: "_test\\.go"
-      linters:
-        - bodyclose
-        - dupl
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - canonicalheader
+    - copyloopvar
+    - cyclop
+    - dupl
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - forbidigo
+    - funlen
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gochecksumtype
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - intrange
+    - loggercheck
+    - makezero
+    - mirror
+    - mnd
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testableexamples
+    - testifylint
+    - testpackage
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+  settings:
+    cyclop:
+      max-complexity: 30
+      package-average: 10
+    errcheck:
+      check-type-assertions: true
+    exhaustive:
+      check:
+        - switch
+        - map
+    exhaustruct:
+      exclude:
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+    funlen:
+      lines: 100
+      statements: 50
+      ignore-comments: true
+    gocognit:
+      min-complexity: 20
+    gocritic:
+      settings:
+        captLocal:
+          paramsOnly: false
+        underef:
+          skipRecvDeref: false
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/golang/protobuf:
+              recommendations:
+                - google.golang.org/protobuf
+              reason: see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+          - github.com/satori/go.uuid:
+              recommendations:
+                - github.com/google/uuid
+              reason: satori's package is not maintained
+          - github.com/gofrs/uuid:
+              recommendations:
+                - github.com/gofrs/uuid/v5
+              reason: gofrs' package was not go module before v5
+    gosec:
+      excludes:
+        - G406
+        - G507
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+    inamedparam:
+      skip-single-param: true
+    mnd:
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+    nakedret:
+      max-func-lines: 0
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
         - funlen
-        - goconst
-        - gosec
-        - noctx
-        - wrapcheck
-
+        - gocognit
+        - lll
+    perfsprint:
+      strconcat: false
+    rowserrcheck:
+      packages:
+        - github.com/jmoiron/sqlx
+    sloglint:
+      no-global: all
+      context: scope
+    staticcheck:
+      checks:
+        - -SA1019
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gochecknoglobals
+          - gochecknoinits
+        path: ^cmd/.*
+      - linters:
+          - godot
+        source: (noinspection|TODO)
+      - linters:
+          - gocritic
+        source: //noinspection
+      - linters:
+          - bodyclose
+          - dupl
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 50
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Define directories
 OUTPUT_DIR := bin
+TOOLS_DIR := .tools
 NODE_PROTOBUF_DIR := pkg/network/protobuf
 
 CLI_BINARY_NAME   := chainnet-cli
@@ -7,6 +8,8 @@ MINER_BINARY_NAME := chainnet-miner
 NESPV_BINARY_NAME := chainnet-nespv
 NODE_BINARY_NAME  := chainnet-node
 BOT_BINARY_NAME   := chainnet-bot
+GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT := $(TOOLS_DIR)/golangci-lint
 
 # Define the source file for the CLI application
 CLI_SOURCE   := $(wildcard cmd/cli/*.go)
@@ -65,10 +68,18 @@ protobuf:
 output-dir:
 	@mkdir -p $(OUTPUT_DIR)
 
+.PHONY: lint-tools
+lint-tools: $(GOLANGCI_LINT)
+
+$(GOLANGCI_LINT):
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
+	@mkdir -p $(TOOLS_DIR)
+	@GOBIN=$(CURDIR)/$(TOOLS_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 .PHONY: lint
-lint: protobuf
+lint: protobuf lint-tools
 	@echo "Running linter..."
-	@golangci-lint run ./...
+	@$(GOLANGCI_LINT) run ./...
 
 .PHONY: test
 test: protobuf

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -175,7 +175,7 @@ func main() { //nolint:funlen,gocognit,nolintlint // this is a main function, it
 		}
 
 		// retrieve account and start the generation of transactions among the wallets contained
-		account, errAcc := hdWallet.GetAccount(uint(i)) //nolint:gosec // safe conversion from int to uint
+		account, errAcc := hdWallet.GetAccount(uint(i))
 		if errAcc != nil {
 			logger.Fatalf("error getting account: %v", errAcc)
 		}
@@ -245,7 +245,7 @@ func DistributeFundsAmongAccounts(hdWallet *hd_wallet.Wallet) error {
 		targetAmounts = append(targetAmounts, distributeFundsAmount)
 
 		// retrieve the account and choose the wallet to send the funds to
-		account, errAccount := hdWallet.GetAccount(uint(i)) //nolint:gosec // safe conversion from int to uint
+		account, errAccount := hdWallet.GetAccount(uint(i))
 		if errAccount != nil {
 			return fmt.Errorf("error getting account: %w", errAccount)
 		}
@@ -339,7 +339,7 @@ func DistributeFundsBetweenWallets(acc *hd_wallet.Account) { //nolint:funlen,goc
 			}
 
 			// create/send transaction and add one tx for the fee recipient
-			amounts := getRandomAmounts(util.GetBalanceUTXOs(utxos), uint(len(addresses)+1)) //nolint:gosec // safe conversion from int to uint
+			amounts := getRandomAmounts(util.GetBalanceUTXOs(utxos), uint(len(addresses)+1))
 			if errTx := createAndSendTransaction(acc, addresses, amounts[:len(amounts)-1], amounts[len(amounts)-1], utxos); errTx != nil {
 				logger.Warnf("error creating and sending transaction: %v", errTx)
 			}

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -38,7 +38,7 @@ var (
 	)
 )
 
-func main() { //nolint:funlen // it's OK to be long here
+func main() {
 	var block *kernel.Block
 
 	// execute the root command
@@ -129,9 +129,7 @@ func main() { //nolint:funlen // it's OK to be long here
 			cfg.Logger.Fatalf("error starting prometheus exporter: %s", err)
 		}
 
-		if err == nil {
-			cfg.Logger.Infof("exposing Prometheus metrics in http://localhost:%d%s", cfg.Prometheus.Port, cfg.Prometheus.Path)
-		}
+		cfg.Logger.Infof("exposing Prometheus metrics in http://localhost:%d%s", cfg.Prometheus.Port, cfg.Prometheus.Path)
 	}
 
 	for {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -117,9 +117,7 @@ func main() {
 			cfg.Logger.Fatalf("error starting prometheus exporter: %s", err)
 		}
 
-		if err == nil {
-			cfg.Logger.Infof("exposing Prometheus metrics in http://localhost:%d%s", cfg.Prometheus.Port, cfg.Prometheus.Path)
-		}
+		cfg.Logger.Infof("exposing Prometheus metrics in http://localhost:%d%s", cfg.Prometheus.Port, cfg.Prometheus.Path)
 	}
 
 	select {}

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -150,26 +150,31 @@ func (bc *Blockchain) InitNetwork(netSubject observer.NetSubject) (*network.Node
 	// create new P2P node
 	chainExplorer := explorer.NewChainExplorer(bc.store, bc.hasher)
 	mempoolExplorer := mempool.NewMemPoolExplorer(bc.mempool)
-	bc.p2pCtx, bc.p2pCancelCtx = context.WithCancel(context.Background())
+	p2pCtx, p2pCancelCtx := context.WithCancel(context.Background())
 
-	p2pNet, err := network.NewNodeP2P(bc.p2pCtx, bc.cfg, netSubject, bc.p2pEncoder, chainExplorer, mempoolExplorer)
+	p2pNet, err := network.NewNodeP2P(p2pCtx, bc.cfg, netSubject, bc.p2pEncoder, chainExplorer, mempoolExplorer)
 	if err != nil {
+		p2pCancelCtx()
 		return nil, fmt.Errorf("error creating p2p node discovery: %w", err)
 	}
 
 	// start the p2p node
 	if err = p2pNet.Start(); err != nil {
+		p2pCancelCtx()
 		return nil, fmt.Errorf("error starting p2p node: %w", err)
 	}
-
-	bc.p2pNet = p2pNet
-	bc.p2pActive = true
 
 	// todo() relocate this, in general this InitNetwork method seems OFF
 	// connect to node seeds
 	if err = p2pNet.ConnectToSeeds(); err != nil {
+		p2pCancelCtx()
 		return nil, fmt.Errorf("error connecting to seeds: %w", err)
 	}
+
+	bc.p2pCtx = p2pCtx
+	bc.p2pCancelCtx = p2pCancelCtx
+	bc.p2pNet = p2pNet
+	bc.p2pActive = true
 
 	return p2pNet, nil
 }
@@ -442,7 +447,7 @@ func (bc *Blockchain) RegisterMetrics(registry *prometheus.Registry) { //nolint:
 			reward /= 2
 		}
 
-		return kernel.ConvertFromChannoshisToCoins(uint(totalSupply)) //nolint:gosec // int to uint is safe
+		return kernel.ConvertFromChannoshisToCoins(uint(totalSupply))
 	})
 
 	monitor.NewMetric(registry, monitor.Gauge, "chain_last_block_size", "Size of latest block added to chain", func() float64 {

--- a/pkg/chain/explorer/explorer.go
+++ b/pkg/chain/explorer/explorer.go
@@ -223,7 +223,7 @@ func (explorer *ChainExplorer) findUnspentTransactions(address string, it iterat
 
 			for outIdx, out := range tx.Vout {
 				// in case is already spent, continue
-				if isOutputSpent(spentTXOs, txID, uint(outIdx)) { //nolint:gosec // int to uint is safe
+				if isOutputSpent(spentTXOs, txID, uint(outIdx)) {
 					continue
 				}
 
@@ -297,7 +297,7 @@ func (explorer *ChainExplorer) findUnspentOutputs(address string, it iterator.Bl
 		for _, tx := range nextBlock.Transactions {
 			for outIdx, out := range tx.Vout {
 				// in case is already spent, continue
-				if isOutputSpent(spentTXOs, string(tx.ID), uint(outIdx)) { //nolint:gosec // int to uint is safe
+				if isOutputSpent(spentTXOs, string(tx.ID), uint(outIdx)) {
 					continue
 				}
 
@@ -305,7 +305,7 @@ func (explorer *ChainExplorer) findUnspentOutputs(address string, it iterator.Bl
 				if out.CanBeUnlockedWith(address) {
 					unspentTXOs = append(unspentTXOs, &kernel.UTXO{
 						TxID:   tx.ID,
-						OutIdx: uint(outIdx), //nolint:gosec // int to uint is safe
+						OutIdx: uint(outIdx),
 						Output: out,
 					})
 				}
@@ -355,7 +355,7 @@ func (explorer *ChainExplorer) FindAmountSpendableOutputs(address string, amount
 		for outIdx, out := range tx.Vout {
 			if out.CanBeUnlockedWith(address) {
 				accumulated += out.Amount
-				unspentOutputs[txID] = append(unspentOutputs[txID], uint(outIdx)) //nolint:gosec // int to uint is safe
+				unspentOutputs[txID] = append(unspentOutputs[txID], uint(outIdx))
 
 				// return once we reached the required amount
 				if accumulated >= amount {

--- a/pkg/kernel/block.go
+++ b/pkg/kernel/block.go
@@ -69,7 +69,7 @@ func (bh *BlockHeader) Assemble() []byte {
 }
 
 func (bh *BlockHeader) Size() uint {
-	return uint(len(bh.Version) + len(bh.PrevBlockHash) + len(bh.MerkleRoot) + int(unsafe.Sizeof(uint(0)))*3 + int(unsafe.Sizeof(int64(0)))) //nolint:gosec // this is used for metrics only
+	return uint(len(bh.Version) + len(bh.PrevBlockHash) + len(bh.MerkleRoot) + int(unsafe.Sizeof(uint(0)))*3 + int(unsafe.Sizeof(int64(0))))
 }
 
 type Block struct {

--- a/pkg/kernel/transaction.go
+++ b/pkg/kernel/transaction.go
@@ -237,7 +237,7 @@ func (in *TxInput) UniqueTxoKey() string {
 }
 
 func (in *TxInput) Size() uint {
-	return uint(len(in.Txid) + int(unsafe.Sizeof(uint(0))) + len(in.ScriptSig) + len(in.PubKey)) //nolint:gosec // this is used for metrics only
+	return uint(len(in.Txid) + int(unsafe.Sizeof(uint(0))) + len(in.ScriptSig) + len(in.PubKey))
 }
 
 // EqualInput checks if the input is the same as the given input
@@ -298,5 +298,5 @@ func (out *TxOutput) String() string {
 }
 
 func (out *TxOutput) Size() uint {
-	return uint(int(unsafe.Sizeof(uint(0))) + len(out.ScriptPubKey) + len(out.PubKey)) //nolint:gosec // this is used for metrics only
+	return uint(int(unsafe.Sizeof(uint(0))) + len(out.ScriptPubKey) + len(out.PubKey))
 }

--- a/pkg/miner/pow.go
+++ b/pkg/miner/pow.go
@@ -80,7 +80,7 @@ func (pow *ProofOfWork) CalculateBlockHash() ([]byte, uint, error) {
 	// split work and ranges among go routines
 	for i := range make([]int, numGoroutines) {
 		pow.wg.Add(1)
-		go pow.startMining(blockMinedCtx, *pow.bh, nonceRange, uint(i)*nonceRange) //nolint:gosec // int to uint is safe
+		go pow.startMining(blockMinedCtx, *pow.bh, nonceRange, uint(i)*nonceRange)
 	}
 
 	// wait for all go routines to finish

--- a/pkg/network/p2p_node.go
+++ b/pkg/network/p2p_node.go
@@ -259,7 +259,7 @@ type NodeP2P struct {
 	logger *logrus.Logger
 }
 
-func NewNodeP2P( //nolint:funlen // this function requires a lot of parameters
+func NewNodeP2P(
 	ctx context.Context,
 	cfg *config.Config,
 	netSubject observer.NetSubject,

--- a/pkg/script/script.go
+++ b/pkg/script/script.go
@@ -170,7 +170,7 @@ func (s Script) String(arg []byte) string {
 				literalRendered = pubKeyHash
 			}
 
-			toRender = fmt.Sprintf("%c%s", byte(element.ToUint()), base58.Encode(literalRendered))
+			toRender = fmt.Sprintf("%c%s", element, base58.Encode(literalRendered))
 		}
 
 		// render operators

--- a/pkg/utxoset/utxos.go
+++ b/pkg/utxoset/utxos.go
@@ -60,7 +60,7 @@ func (u *UTXOSet) AddBlock(block *kernel.Block) error {
 		for index, output := range tx.Vout {
 			utxo := kernel.UTXO{
 				TxID:   tx.ID,
-				OutIdx: uint(index), //nolint:gosec // int to uint is safe
+				OutIdx: uint(index),
 				Output: output,
 			}
 

--- a/pkg/wallet/hd_wallet/common.go
+++ b/pkg/wallet/hd_wallet/common.go
@@ -1,6 +1,7 @@
 package hdwallet
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -213,7 +214,7 @@ func deriveChildStep(derivedKey []byte, chainCode []byte, index uint32) ([]byte,
 
 	// serialize index value as a 4-byte big-endian representation in byte array form
 	data = append(data, derivedKey...)
-	data = append(data, byte(index>>24), byte(index>>16), byte(index>>8), byte(index)) //nolint:mnd // 4 bytes, no const needed
+	data = binary.BigEndian.AppendUint32(data, index)
 
 	// apply initial hmac
 	hmacOutput, err := util_crypto.CalculateHMACSha512(chainCode, data)


### PR DESCRIPTION
Handle migration from v1 to v2 `golangci lint`