### PR TITLE
Use remote SDK for all targets

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -11,10 +11,10 @@ import (
 
 	hd_wallet "github.com/yago-123/chainnet/pkg/wallet/hd_wallet"
 
-	"github.com/yago-123/chainnet/pkg/util"
 	wallt "github.com/yago-123/chainnet/pkg/wallet/simple_wallet"
 
 	"github.com/btcsuite/btcutil/base58"
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/pkg/kernel"
 	"github.com/yago-123/chainnet/pkg/script"
 
@@ -319,7 +319,7 @@ func DistributeFundsBetweenWallets(acc *hd_wallet.Account) { //nolint:funlen,goc
 			addresses := [][]byte{}
 
 			// if the utxo is small than the minimum transaction balance, send it to a single address
-			if util.GetBalanceUTXOs(utxos) <= MinimumTxBalance {
+			if balanceSDKUTXOs(utxos) <= MinimumTxBalance {
 				addr, errTmp := getRandomAccountAddress(acc)
 				if errTmp != nil {
 					logger.Warnf("error getting random account address: %v", errTmp)
@@ -330,7 +330,7 @@ func DistributeFundsBetweenWallets(acc *hd_wallet.Account) { //nolint:funlen,goc
 			}
 
 			// otherwise, split the UTXO in a number of random addresses and amounts
-			if util.GetBalanceUTXOs(utxos) > MinimumTxBalance {
+			if balanceSDKUTXOs(utxos) > MinimumTxBalance {
 				addresses, err = getRandomAccountAddresses(1, MaxOutputGroupsForCreatingTx, acc)
 				if err != nil {
 					logger.Warnf("error getting random account addresses: %v", err)
@@ -339,7 +339,7 @@ func DistributeFundsBetweenWallets(acc *hd_wallet.Account) { //nolint:funlen,goc
 			}
 
 			// create/send transaction and add one tx for the fee recipient
-			amounts := getRandomAmounts(util.GetBalanceUTXOs(utxos), uint(len(addresses)+1))
+			amounts := getRandomAmounts(balanceSDKUTXOs(utxos), uint(len(addresses)+1))
 			if errTx := createAndSendTransaction(acc, addresses, amounts[:len(amounts)-1], amounts[len(amounts)-1], utxos); errTx != nil {
 				logger.Warnf("error creating and sending transaction: %v", errTx)
 			}
@@ -398,7 +398,7 @@ func randomizedSleep(minDuration, maxDuration time.Duration) {
 	time.Sleep(randomDuration)
 }
 
-func createAndSendTransaction(acc *hd_wallet.Account, addresses [][]byte, amounts []uint, txFee uint, utxos []*kernel.UTXO) error {
+func createAndSendTransaction(acc *hd_wallet.Account, addresses [][]byte, amounts []uint, txFee uint, utxos []sdkv1beta.UTXO) error {
 	var err error
 	var wallet *wallt.Wallet
 
@@ -430,18 +430,27 @@ func createAndSendTransaction(acc *hd_wallet.Account, addresses [][]byte, amount
 	ctx, cancel := context.WithTimeout(context.Background(), TimeoutSendTransaction)
 	defer cancel()
 
-	if errSend := acc.SendTransaction(ctx, tx); errSend != nil {
+	if errSend := acc.SendTransaction(ctx, *tx); errSend != nil {
 		return fmt.Errorf("error sending transaction: %w", errSend)
 	}
 
 	logger.Debugf("account %d distributed %f coins to %d addresses: %s",
 		acc.GetAccountID(),
-		kernel.ConvertFromChannoshisToCoins(util.GetBalanceUTXOs(utxos)),
+		kernel.ConvertFromChannoshisToCoins(balanceSDKUTXOs(utxos)),
 		len(addresses),
-		tx.String(),
+		fmt.Sprintf("%+v", tx),
 	)
 
 	return nil
+}
+
+func balanceSDKUTXOs(utxos []sdkv1beta.UTXO) uint {
+	var balance uint
+	for _, utxo := range utxos {
+		balance += utxo.Amount()
+	}
+
+	return balance
 }
 
 // getRandomAccountAddress retrieves a random address for an account. If the limit of wallets per account has been

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/config"
-	sdkv1beta "github.com/yago-123/chainnet/pkg/sdk/v1beta"
 )
 
 const FlagAddress = "address"

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/spf13/cobra"
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/config"
 	sdkv1beta "github.com/yago-123/chainnet/pkg/sdk/v1beta"
 )
@@ -39,8 +40,7 @@ var listTxsCmd = &cobra.Command{
 
 		// print transactions
 		for _, tx := range txs {
-
-			logger.Infof("{\n%s}\n", tx.String())
+			logger.Infof("{\n%+v}\n", tx)
 		}
 	},
 }

--- a/cmd/nespv/cmd/send.go
+++ b/cmd/nespv/cmd/send.go
@@ -101,12 +101,12 @@ var sendCmd = &cobra.Command{
 		context, cancel := context.WithTimeout(context.Background(), cfg.P2P.ConnTimeout)
 		defer cancel()
 
-		err = wallet.SendTransaction(context, tx)
+		err = wallet.SendTransaction(context, *tx)
 		if err != nil {
 			logger.Fatalf("error sending transaction: %v", err)
 		}
 
-		logger.Infof("Sent transaction: %s", tx.String())
+		logger.Infof("Sent transaction: %+v", tx)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/yago-123/chainnet-sdk-go v0.2.0-rc.1
 	golang.org/x/crypto v0.50.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdz
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
+github.com/yago-123/chainnet-sdk-go v0.2.0-rc.1 h1:b8CuqVticZiYwnfSxu9apj/kVHiL3TFhzvPjC1Drw+s=
+github.com/yago-123/chainnet-sdk-go v0.2.0-rc.1/go.mod h1:42LunTOF6znd1iWgbBKzHJfS5cehMltH6T29BhcYKb4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -768,8 +770,6 @@ golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
-golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/wallet/hd_wallet/account.go
+++ b/pkg/wallet/hd_wallet/account.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sync"
 
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/pkg/kernel"
 	"github.com/yago-123/chainnet/pkg/script"
 	rpnInter "github.com/yago-123/chainnet/pkg/script/interpreter"
-	sdkv1beta "github.com/yago-123/chainnet/pkg/sdk/v1beta"
 	"github.com/yago-123/chainnet/pkg/util"
 	common "github.com/yago-123/chainnet/pkg/wallet"
 
@@ -75,7 +75,10 @@ func NewHDAccount(
 	externalWalletsNum uint32,
 	internalWalletsNum uint32,
 ) (*Account, error) {
-	nodeClient, err := sdkv1beta.NewClientFromConfig(cfg, nil)
+	nodeClient, err := sdkv1beta.NewClient(
+		fmt.Sprintf("%s:%d", cfg.Wallet.ServerAddress, cfg.Wallet.ServerPort),
+		nil,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create wallet node client: %w", err)
 	}
@@ -256,7 +259,8 @@ func (hda *Account) GetInternalWallet(idx uint) (*wallt.Wallet, error) {
 	return hda.internalWallets[idx], nil
 }
 
-func (hda *Account) GenerateNewTransaction(scriptType script.ScriptType, addresses [][]byte, targetAmount []uint, txFee uint, changeReceiverPubKey []byte, changeReceiverVersion byte, utxos []*kernel.UTXO) (*kernel.Transaction, error) {
+// GenerateNewTransaction creates a transaction using wallet-owned SDK types.
+func (hda *Account) GenerateNewTransaction(scriptType script.ScriptType, addresses [][]byte, targetAmount []uint, txFee uint, changeReceiverPubKey []byte, changeReceiverVersion byte, utxos []sdkv1beta.UTXO) (*sdkv1beta.Transaction, error) {
 	hda.mu.Lock()
 	defer hda.mu.Unlock()
 
@@ -266,9 +270,9 @@ func (hda *Account) GenerateNewTransaction(scriptType script.ScriptType, address
 		totalTargetAmount += amount
 	}
 
-	inputs, totalBalance, err := common.GenerateInputs(utxos, totalTargetAmount+txFee)
+	inputs, totalBalance, err := common.GenerateInputs(common.SDKUTXOsToKernel(utxos), totalTargetAmount+txFee)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	outputs, err := common.GenerateOutputs(scriptType, targetAmount, addresses, txFee, totalBalance, changeReceiverPubKey, changeReceiverVersion)
@@ -283,42 +287,46 @@ func (hda *Account) GenerateNewTransaction(scriptType script.ScriptType, address
 	)
 
 	// unlock the funds from the UTXOs
-	tx, err = hda.UnlockTxFunds(tx, utxos)
+	sdkTx := common.KernelTransactionToSDK(*tx)
+	sdkTxPtr, err := hda.UnlockTxFunds(&sdkTx, utxos)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// generate tx hash
-	txHash, err := util.CalculateTxHash(tx, hda.consensusHasher)
+	txHash, err := util.CalculateTxHash(common.SDKTransactionToKernel(sdkTxPtr), hda.consensusHasher)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// assign the tx hash
-	tx.SetID(txHash)
+	sdkTxPtr.ID = txHash
 
 	// perform simple validations (light validator) before broadcasting the transaction
-	if err = hda.validator.ValidateTxLight(tx); err != nil {
-		return &kernel.Transaction{}, fmt.Errorf("error validating transaction: %w", err)
+	if err = hda.validator.ValidateTxLight(common.SDKTransactionToKernel(sdkTxPtr)); err != nil {
+		return &sdkv1beta.Transaction{}, fmt.Errorf("error validating transaction: %w", err)
 	}
 
-	return tx, nil
+	return sdkTxPtr, nil
 }
 
 // UnlockTxFunds unlocks the funds from the UTXOs by generating the scriptSigs for the inputs
-func (hda *Account) UnlockTxFunds(tx *kernel.Transaction, utxos []*kernel.UTXO) (*kernel.Transaction, error) {
+func (hda *Account) UnlockTxFunds(tx *sdkv1beta.Transaction, utxos []sdkv1beta.UTXO) (*sdkv1beta.Transaction, error) {
 	// precompute wallets for lookup
 	wallets := append(hda.externalWallets, hda.internalWallets...) //nolint:gocritic // simpler to use a single append
 
 	// map UTXOs so that can be easily accessed for generating the scriptSigs for the inputs
+	kernelTx := common.SDKTransactionToKernel(tx)
+	kernelUtxos := common.SDKUTXOsToKernel(utxos)
+
 	utxoMap := make(map[string]*kernel.UTXO)
-	for _, utxo := range utxos {
+	for _, utxo := range kernelUtxos {
 		utxoMap[utxo.UniqueKey()] = utxo
 	}
 
-	scriptSigs := make([]string, len(tx.Vin))
+	scriptSigs := make([]string, len(kernelTx.Vin))
 	// iterate through each input and unlock the funds
-	for i, vin := range tx.Vin {
+	for i, vin := range kernelTx.Vin {
 		// retrieve the UTXO that will spend the input so that the scriptPubKey can be analyzed and unlocked
 		utxo, found := utxoMap[vin.UniqueTxoKey()]
 		if !found {
@@ -331,7 +339,7 @@ func (hda *Account) UnlockTxFunds(tx *kernel.Transaction, utxos []*kernel.UTXO) 
 		for _, wallet := range wallets {
 			if script.CanBeUnlockedWith(utxo.Output.ScriptPubKey, wallet.PublicKey(), wallet.Version()) {
 				// generate the unlocking script
-				scriptSig, err := hda.interpreter.GenerateScriptSig(utxo.Output.ScriptPubKey, wallet.PublicKey(), wallet.PrivateKey(), tx)
+				scriptSig, err := hda.interpreter.GenerateScriptSig(utxo.Output.ScriptPubKey, wallet.PublicKey(), wallet.PrivateKey(), kernelTx)
 				if err != nil {
 					return nil, fmt.Errorf("couldn't generate scriptSig for input with ID %x and index %d: %w", vin.Txid, vin.Vout, err)
 				}
@@ -349,29 +357,26 @@ func (hda *Account) UnlockTxFunds(tx *kernel.Transaction, utxos []*kernel.UTXO) 
 	}
 
 	// assign scriptSigs to transaction inputs
-	for i := range tx.Vin {
-		tx.Vin[i].ScriptSig = scriptSigs[i]
+	for i := range kernelTx.Vin {
+		kernelTx.Vin[i].ScriptSig = scriptSigs[i]
 	}
 
-	return tx, nil
+	sdkTx := common.KernelTransactionToSDK(*kernelTx)
+	return &sdkTx, nil
 }
 
 // SendTransaction propagates a transaction to the network
-func (hda *Account) SendTransaction(ctx context.Context, tx *kernel.Transaction) error {
-	if err := hda.nodeClient.SendTransaction(ctx, *tx); err != nil {
-		return fmt.Errorf("error sending transaction %x to the network: %w", tx.ID, err)
-	}
-
-	return nil
+func (hda *Account) SendTransaction(ctx context.Context, tx sdkv1beta.Transaction) error {
+	return hda.nodeClient.SendTransaction(ctx, tx)
 }
 
 // GetAccountUTXOs retrieves the UTXOs from both external and internal wallets
-func (hda *Account) GetAccountUTXOs() ([]*kernel.UTXO, error) {
+func (hda *Account) GetAccountUTXOs() ([]sdkv1beta.UTXO, error) {
 	hda.mu.Lock()
 	wallets := append(hda.externalWallets, hda.internalWallets...) //nolint:gocritic // simpler to use a single append
 	hda.mu.Unlock()
 
-	var utxosCollection []*kernel.UTXO
+	var utxosCollection []sdkv1beta.UTXO
 	var utxosMu sync.Mutex
 
 	// create a context with cancellation

--- a/pkg/wallet/sdk_convert.go
+++ b/pkg/wallet/sdk_convert.go
@@ -1,0 +1,83 @@
+package wallet
+
+import (
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
+	"github.com/yago-123/chainnet/pkg/kernel"
+)
+
+// These functions are needed in order to access
+
+func KernelTransactionToSDK(tx kernel.Transaction) sdkv1beta.Transaction {
+	inputs := make([]sdkv1beta.TxInput, 0, len(tx.Vin))
+	for _, input := range tx.Vin {
+		inputs = append(inputs, sdkv1beta.TxInput{
+			Txid:      input.Txid,
+			Vout:      input.Vout,
+			ScriptSig: input.ScriptSig,
+			PubKey:    input.PubKey,
+		})
+	}
+
+	outputs := make([]sdkv1beta.TxOutput, 0, len(tx.Vout))
+	for _, output := range tx.Vout {
+		outputs = append(outputs, sdkv1beta.TxOutput{
+			Amount:       output.Amount,
+			ScriptPubKey: output.ScriptPubKey,
+			PubKey:       output.PubKey,
+		})
+	}
+
+	return sdkv1beta.Transaction{
+		ID:   tx.ID,
+		Vin:  inputs,
+		Vout: outputs,
+	}
+}
+
+func SDKTransactionToKernel(tx *sdkv1beta.Transaction) *kernel.Transaction {
+	inputs := make([]kernel.TxInput, 0, len(tx.Vin))
+	for _, input := range tx.Vin {
+		inputs = append(inputs, kernel.TxInput{
+			Txid:      input.Txid,
+			Vout:      input.Vout,
+			ScriptSig: input.ScriptSig,
+			PubKey:    input.PubKey,
+		})
+	}
+
+	outputs := make([]kernel.TxOutput, 0, len(tx.Vout))
+	for _, output := range tx.Vout {
+		outputs = append(outputs, kernel.TxOutput{
+			Amount:       output.Amount,
+			ScriptPubKey: output.ScriptPubKey,
+			PubKey:       output.PubKey,
+		})
+	}
+
+	return &kernel.Transaction{
+		ID:   tx.ID,
+		Vin:  inputs,
+		Vout: outputs,
+	}
+}
+
+func SDKUTXOToKernel(utxo sdkv1beta.UTXO) *kernel.UTXO {
+	return &kernel.UTXO{
+		TxID:   utxo.TxID,
+		OutIdx: utxo.OutIdx,
+		Output: kernel.TxOutput{
+			Amount:       utxo.Output.Amount,
+			ScriptPubKey: utxo.Output.ScriptPubKey,
+			PubKey:       utxo.Output.PubKey,
+		},
+	}
+}
+
+func SDKUTXOsToKernel(utxos []sdkv1beta.UTXO) []*kernel.UTXO {
+	ret := make([]*kernel.UTXO, 0, len(utxos))
+	for _, utxo := range utxos {
+		ret = append(ret, SDKUTXOToKernel(utxo))
+	}
+
+	return ret
+}

--- a/pkg/wallet/simple_wallet/wallet.go
+++ b/pkg/wallet/simple_wallet/wallet.go
@@ -10,6 +10,7 @@ import (
 
 	util_p2pkh "github.com/yago-123/chainnet/pkg/util/p2pkh"
 
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/config"
 	"github.com/yago-123/chainnet/pkg/consensus"
 	"github.com/yago-123/chainnet/pkg/crypto/hash"
@@ -18,7 +19,6 @@ import (
 	"github.com/yago-123/chainnet/pkg/kernel"
 	"github.com/yago-123/chainnet/pkg/script"
 	rpnInter "github.com/yago-123/chainnet/pkg/script/interpreter"
-	sdkv1beta "github.com/yago-123/chainnet/pkg/sdk/v1beta"
 	"github.com/yago-123/chainnet/pkg/util"
 )
 
@@ -75,7 +75,10 @@ func NewWalletWithKeys(
 	privateKey []byte,
 	publicKey []byte,
 ) (*Wallet, error) {
-	nodeClient, err := sdkv1beta.NewClientFromConfig(cfg, nil)
+	nodeClient, err := sdkv1beta.NewClient(
+		fmt.Sprintf("%s:%d", cfg.Wallet.ServerAddress, cfg.Wallet.ServerPort),
+		nil,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create wallet node client: %w", err)
 	}
@@ -120,13 +123,13 @@ func (w *Wallet) GetAddresses() ([][]byte, error) {
 	return addresses, nil
 }
 
-func (w *Wallet) GetWalletUTXOS() ([]*kernel.UTXO, error) {
+func (w *Wallet) GetWalletUTXOS() ([]sdkv1beta.UTXO, error) {
 	addresses, err := w.GetAddresses()
 	if err != nil {
-		return []*kernel.UTXO{}, fmt.Errorf("could not get wallet addresses: %w", err)
+		return []sdkv1beta.UTXO{}, fmt.Errorf("could not get wallet addresses: %w", err)
 	}
 
-	utxos := make([]*kernel.UTXO, 0)
+	utxos := make([]sdkv1beta.UTXO, 0)
 	for _, address := range addresses {
 		ctx, cancel := context.WithTimeout(context.Background(), w.cfg.P2P.ConnTimeout)
 		defer cancel()
@@ -134,7 +137,7 @@ func (w *Wallet) GetWalletUTXOS() ([]*kernel.UTXO, error) {
 		// retrieve UTXOs for each address
 		utxo, errUtxos := w.nodeClient.GetAddressUTXOs(ctx, address)
 		if errUtxos != nil {
-			return []*kernel.UTXO{}, fmt.Errorf("could not get wallet UTXOs for address %s: %w", base58.Encode(address), errUtxos)
+			return []sdkv1beta.UTXO{}, fmt.Errorf("could not get wallet UTXOs for address %s: %w", base58.Encode(address), errUtxos)
 		}
 
 		utxos = append(utxos, utxo...)
@@ -144,21 +147,21 @@ func (w *Wallet) GetWalletUTXOS() ([]*kernel.UTXO, error) {
 }
 
 // GetWalletTxs retrieves all the transactions that are related to the wallet
-func (w *Wallet) GetWalletTxs() ([]*kernel.Transaction, error) {
+func (w *Wallet) GetWalletTxs() ([]*sdkv1beta.Transaction, error) {
 	addresses, err := w.GetAddresses()
 	if err != nil {
-		return []*kernel.Transaction{}, fmt.Errorf("could not get wallet addresses: %w", err)
+		return []*sdkv1beta.Transaction{}, fmt.Errorf("could not get wallet addresses: %w", err)
 	}
 
-	txs := make([]*kernel.Transaction, 0)
+	txs := make([]*sdkv1beta.Transaction, 0)
 	for _, address := range addresses {
 		ctx, cancel := context.WithTimeout(context.Background(), w.cfg.P2P.ConnTimeout)
 		defer cancel()
 
 		// retrieve txs for each address
-		tx, errUtxos := w.nodeClient.GetAddressTransactions(ctx, address)
-		if errUtxos != nil {
-			return []*kernel.Transaction{}, fmt.Errorf("could not get wallet UTXOs for address %s: %w", base58.Encode(address), errUtxos)
+		tx, errTxs := w.nodeClient.GetAddressTransactions(ctx, address)
+		if errTxs != nil {
+			return []*sdkv1beta.Transaction{}, fmt.Errorf("could not get wallet transactions for address %s: %w", base58.Encode(address), errTxs)
 		}
 
 		txs = append(txs, tx...)
@@ -192,18 +195,18 @@ func (w *Wallet) CheckIfWalletIsActive() (bool, error) {
 	return false, nil
 }
 
-// GenerateNewTransaction creates a transaction and broadcasts it to the network
-func (w *Wallet) GenerateNewTransaction(scriptType script.ScriptType, addresses []byte, targetAmount uint, txFee uint, utxos []*kernel.UTXO) (*kernel.Transaction, error) {
+// GenerateNewTransaction creates a transaction using wallet-owned SDK types.
+func (w *Wallet) GenerateNewTransaction(scriptType script.ScriptType, addresses []byte, targetAmount uint, txFee uint, utxos []sdkv1beta.UTXO) (*sdkv1beta.Transaction, error) {
 	// create the inputs necessary for the transaction
-	inputs, totalBalance, err := common.GenerateInputs(utxos, targetAmount+txFee)
+	inputs, totalBalance, err := common.GenerateInputs(common.SDKUTXOsToKernel(utxos), targetAmount+txFee)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// create the outputs necessary for the transaction
 	outputs, err := common.GenerateOutputs(scriptType, []uint{targetAmount}, [][]byte{addresses}, txFee, totalBalance, w.publicKey, w.version)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// generate transaction
@@ -213,42 +216,46 @@ func (w *Wallet) GenerateNewTransaction(scriptType script.ScriptType, addresses 
 	)
 
 	// unlock the funds from the UTXOs
-	tx, err = w.UnlockTxFunds(tx, utxos)
+	sdkTx := common.KernelTransactionToSDK(*tx)
+	sdkTxPtr, err := w.UnlockTxFunds(&sdkTx, utxos)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// generate tx hash
-	txHash, err := util.CalculateTxHash(tx, w.consensusHasher)
+	txHash, err := util.CalculateTxHash(common.SDKTransactionToKernel(sdkTxPtr), w.consensusHasher)
 	if err != nil {
-		return &kernel.Transaction{}, err
+		return &sdkv1beta.Transaction{}, err
 	}
 
 	// assign the tx hash
-	tx.SetID(txHash)
+	sdkTxPtr.ID = txHash
 
 	// perform simple validations (light validator) before broadcasting the transaction
-	if err = w.validator.ValidateTxLight(tx); err != nil {
-		return &kernel.Transaction{}, fmt.Errorf("error validating transaction: %w", err)
+	if err = w.validator.ValidateTxLight(common.SDKTransactionToKernel(sdkTxPtr)); err != nil {
+		return &sdkv1beta.Transaction{}, fmt.Errorf("error validating transaction: %w", err)
 	}
 
-	return tx, nil
+	return sdkTxPtr, nil
 }
 
 // UnlockTxFunds take a tx that is being built and unlocks the UTXOs from which the input funds are going to
 // be used
-func (w *Wallet) UnlockTxFunds(tx *kernel.Transaction, utxos []*kernel.UTXO) (*kernel.Transaction, error) {
+func (w *Wallet) UnlockTxFunds(tx *sdkv1beta.Transaction, utxos []sdkv1beta.UTXO) (*sdkv1beta.Transaction, error) {
 	// todo() for now, this only applies to P2PK, be able to extend once pkg/script/interpreter.go is created
+	kernelTx := common.SDKTransactionToKernel(tx)
+	kernelUtxos := common.SDKUTXOsToKernel(utxos)
+
 	scriptSigs := []string{}
-	for _, vin := range tx.Vin {
+	for _, vin := range kernelTx.Vin {
 		unlocked := false
 
-		for _, utxo := range utxos {
+		for _, utxo := range kernelUtxos {
 			if utxo.EqualInput(vin) {
 				// todo(): modify to allow multiple inputs with different scriptPubKeys owners (multiple wallets)
-				scriptSig, err := w.interpreter.GenerateScriptSig(utxo.Output.ScriptPubKey, w.publicKey, w.privateKey, tx)
+				scriptSig, err := w.interpreter.GenerateScriptSig(utxo.Output.ScriptPubKey, w.publicKey, w.privateKey, kernelTx)
 				if err != nil {
-					return &kernel.Transaction{}, fmt.Errorf("couldn't generate scriptSig for input with ID %x and index %d: %w", vin.Txid, vin.Vout, err)
+					return &sdkv1beta.Transaction{}, fmt.Errorf("couldn't generate scriptSig for input with ID %x and index %d: %w", vin.Txid, vin.Vout, err)
 				}
 
 				scriptSigs = append(scriptSigs, scriptSig)
@@ -260,20 +267,21 @@ func (w *Wallet) UnlockTxFunds(tx *kernel.Transaction, utxos []*kernel.UTXO) (*k
 
 		// todo(): modify to allow multiple inputs with different scriptPubKeys owners (multiple wallets)
 		if !unlocked {
-			return &kernel.Transaction{}, fmt.Errorf("couldn't unlock funds for input with ID %x and index %d", vin.Txid, vin.Vout)
+			return &sdkv1beta.Transaction{}, fmt.Errorf("couldn't unlock funds for input with ID %x and index %d", vin.Txid, vin.Vout)
 		}
 	}
 
-	for i := range len(tx.Vin) {
-		tx.Vin[i].ScriptSig = scriptSigs[i]
+	for i := range len(kernelTx.Vin) {
+		kernelTx.Vin[i].ScriptSig = scriptSigs[i]
 	}
 
-	return tx, nil
+	sdkTx := common.KernelTransactionToSDK(*kernelTx)
+	return &sdkTx, nil
 }
 
 // SendTransaction propagates a transaction to the network
-func (w *Wallet) SendTransaction(ctx context.Context, tx *kernel.Transaction) error {
-	if err := w.nodeClient.SendTransaction(ctx, *tx); err != nil {
+func (w *Wallet) SendTransaction(ctx context.Context, tx sdkv1beta.Transaction) error {
+	if err := w.nodeClient.SendTransaction(ctx, tx); err != nil {
 		return fmt.Errorf("error sending transaction %x to the network: %w", tx.ID, err)
 	}
 

--- a/pkg/wallet/simple_wallet/wallet.go
+++ b/pkg/wallet/simple_wallet/wallet.go
@@ -281,11 +281,7 @@ func (w *Wallet) UnlockTxFunds(tx *sdkv1beta.Transaction, utxos []sdkv1beta.UTXO
 
 // SendTransaction propagates a transaction to the network
 func (w *Wallet) SendTransaction(ctx context.Context, tx sdkv1beta.Transaction) error {
-	if err := w.nodeClient.SendTransaction(ctx, tx); err != nil {
-		return fmt.Errorf("error sending transaction %x to the network: %w", tx.ID, err)
-	}
-
-	return nil
+	return w.nodeClient.SendTransaction(ctx, tx)
 }
 
 func (w *Wallet) Version() byte {

--- a/pkg/wallet/simple_wallet/wallet_test.go
+++ b/pkg/wallet/simple_wallet/wallet_test.go
@@ -3,6 +3,7 @@ package simplewallet //nolint:testpackage // don't create separate package for t
 import (
 	"testing"
 
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/config"
 	"github.com/yago-123/chainnet/pkg/consensus/validator"
 	"github.com/yago-123/chainnet/pkg/encoding"
@@ -17,11 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var utxos = []*kernel.UTXO{ //nolint:gochecknoglobals // data that is used across all test funcs
-	{TxID: []byte("random-id-0"), OutIdx: 1, Output: kernel.NewOutput(1, script.P2PK, "pubkey-2")},
-	{TxID: []byte("random-id-1"), OutIdx: 3, Output: kernel.NewOutput(2, script.P2PK, "pubkey-2")},
-	{TxID: []byte("random-id-2"), OutIdx: 1, Output: kernel.NewOutput(5, script.P2PK, "pubkey-2")},
-	{TxID: []byte("random-id-3"), OutIdx: 8, Output: kernel.NewOutput(5, script.P2PK, "pubkey-2")},
+var utxos = []sdkv1beta.UTXO{ //nolint:gochecknoglobals // data that is used across all test funcs
+	{TxID: []byte("random-id-0"), OutIdx: 1, Output: sdkv1beta.TxOutput{Amount: 1, ScriptPubKey: kernel.NewOutput(1, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"}},
+	{TxID: []byte("random-id-1"), OutIdx: 3, Output: sdkv1beta.TxOutput{Amount: 2, ScriptPubKey: kernel.NewOutput(2, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"}},
+	{TxID: []byte("random-id-2"), OutIdx: 1, Output: sdkv1beta.TxOutput{Amount: 5, ScriptPubKey: kernel.NewOutput(5, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"}},
+	{TxID: []byte("random-id-3"), OutIdx: 8, Output: sdkv1beta.TxOutput{Amount: 5, ScriptPubKey: kernel.NewOutput(5, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"}},
 }
 
 func TestWallet_SendTransaction(t *testing.T) {
@@ -44,7 +45,7 @@ func TestWallet_SendTransaction(t *testing.T) {
 	require.Error(t, err)
 
 	// send transaction without utxos
-	_, err = wallet.GenerateNewTransaction(script.P2PK, []byte("pubkey-1"), 10, 1, []*kernel.UTXO{})
+	_, err = wallet.GenerateNewTransaction(script.P2PK, []byte("pubkey-1"), 10, 1, []sdkv1beta.UTXO{})
 	require.Error(t, err)
 
 	// send transaction with incorrect utxos unlocking scripts
@@ -67,17 +68,17 @@ func TestWallet_SendTransactionCheckOutputTx(t *testing.T) {
 	require.NoError(t, err)
 	// send transaction with correct target and empty tx fee
 	tx, err := wallet.GenerateNewTransaction(script.P2PK, []byte("pubkey-1"), 10, 0, utxos)
-	expectedTx := &kernel.Transaction{
+	expectedTx := &sdkv1beta.Transaction{
 		ID: tx.ID,
-		Vin: []kernel.TxInput{
-			kernel.NewInput([]byte("random-id-0"), 1, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-1"), 3, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-2"), 1, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-3"), 8, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
+		Vin: []sdkv1beta.TxInput{
+			{Txid: []byte("random-id-0"), Vout: 1, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-1"), Vout: 3, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-2"), Vout: 1, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-3"), Vout: 8, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo68 OP_CHECKSIGpubkey-13\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
 		},
-		Vout: []kernel.TxOutput{
-			kernel.NewOutput(10, script.P2PK, "pubkey-1"),
-			kernel.NewOutput(3, script.P2PK, "pubkey-2"),
+		Vout: []sdkv1beta.TxOutput{
+			{Amount: 10, ScriptPubKey: kernel.NewOutput(10, script.P2PK, "pubkey-1").ScriptPubKey, PubKey: "pubkey-1"},
+			{Amount: 3, ScriptPubKey: kernel.NewOutput(3, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"},
 		},
 	}
 	require.NoError(t, err)
@@ -85,17 +86,17 @@ func TestWallet_SendTransactionCheckOutputTx(t *testing.T) {
 
 	// send transaction with correct target and some tx fee
 	tx, err = wallet.GenerateNewTransaction(script.P2PK, []byte("pubkey-3"), 10, 2, utxos)
-	expectedTx2 := &kernel.Transaction{
+	expectedTx2 := &sdkv1beta.Transaction{
 		ID: tx.ID,
-		Vin: []kernel.TxInput{
-			kernel.NewInput([]byte("random-id-0"), 1, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-1"), 3, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-2"), 1, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
-			kernel.NewInput([]byte("random-id-3"), 8, base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), "pubkey-2"),
+		Vin: []sdkv1beta.TxInput{
+			{Txid: []byte("random-id-0"), Vout: 1, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-1"), Vout: 3, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-2"), Vout: 1, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
+			{Txid: []byte("random-id-3"), Vout: 8, ScriptSig: base58.Encode([]byte("Inputs:random-id-01random-id-13random-id-21random-id-38Outputs:10\x00KozLnpdoo6A OP_CHECKSIGpubkey-31\x00KozLnpdoo69 OP_CHECKSIGpubkey-2-signed")), PubKey: "pubkey-2"},
 		},
-		Vout: []kernel.TxOutput{
-			kernel.NewOutput(10, script.P2PK, "pubkey-3"),
-			kernel.NewOutput(1, script.P2PK, "pubkey-2"),
+		Vout: []sdkv1beta.TxOutput{
+			{Amount: 10, ScriptPubKey: kernel.NewOutput(10, script.P2PK, "pubkey-3").ScriptPubKey, PubKey: "pubkey-3"},
+			{Amount: 1, ScriptPubKey: kernel.NewOutput(1, script.P2PK, "pubkey-2").ScriptPubKey, PubKey: "pubkey-2"},
 		},
 	}
 	require.NoError(t, err)

--- a/sdk/go/v1beta/client.go.tmpl
+++ b/sdk/go/v1beta/client.go.tmpl
@@ -58,20 +58,30 @@ func (c *Client) GetAddressUTXOsByAddress(ctx context.Context, address string) (
 		return nil, fmt.Errorf("failed to get address UTXOs: %w", err)
 	}
 
-	return expectOK("get address UTXOs", resp.StatusCode(), resp.Body, resp.JSON200)
+	utxos, err := expectOK("get address UTXOs", resp.StatusCode(), resp.Body, resp.JSON200)
+	if err != nil {
+		return nil, err
+	}
+
+	return utxosFromGenerated(utxos)
 }
 
-func (c *Client) GetAddressTransactions(ctx context.Context, address []byte) ([]Transaction, error) {
+func (c *Client) GetAddressTransactions(ctx context.Context, address []byte) ([]*Transaction, error) {
 	return c.GetAddressTransactionsByAddress(ctx, base58.Encode(address))
 }
 
-func (c *Client) GetAddressTransactionsByAddress(ctx context.Context, address string) ([]Transaction, error) {
+func (c *Client) GetAddressTransactionsByAddress(ctx context.Context, address string) ([]*Transaction, error) {
 	resp, err := c.client.GetAddressTransactionsWithResponse(ctx, address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address transactions: %w", err)
 	}
 
-	return expectOK("get address transactions", resp.StatusCode(), resp.Body, resp.JSON200)
+	transactions, err := expectOK("get address transactions", resp.StatusCode(), resp.Body, resp.JSON200)
+	if err != nil {
+		return nil, err
+	}
+
+	return transactionsFromGenerated(transactions)
 }
 
 func (c *Client) AddressIsActive(ctx context.Context, address []byte) (bool, error) {
@@ -88,7 +98,12 @@ func (c *Client) AddressStringIsActive(ctx context.Context, address string) (boo
 }
 
 func (c *Client) SendTransaction(ctx context.Context, tx Transaction) error {
-	resp, err := c.client.SubmitTransactionWithResponse(ctx, tx)
+	body, err := transactionToGenerated(tx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.SubmitTransactionWithResponse(ctx, body)
 	if err != nil {
 		return fmt.Errorf("failed to submit transaction: %w", err)
 	}
@@ -111,7 +126,7 @@ func (c *Client) GetTransactionByIDHex(ctx context.Context, txID string) (*Trans
 		return nil, err
 	}
 
-	return &tx, nil
+	return transactionFromGenerated(tx)
 }
 
 func (c *Client) GetLatestBlock(ctx context.Context) (*Block, error) {
@@ -125,7 +140,7 @@ func (c *Client) GetLatestBlock(ctx context.Context) (*Block, error) {
 		return nil, err
 	}
 
-	return &block, nil
+	return blockFromGenerated(block)
 }
 
 func (c *Client) GetBlockByHash(ctx context.Context, hash []byte) (*Block, error) {
@@ -143,7 +158,7 @@ func (c *Client) GetBlockByHashHex(ctx context.Context, hash string) (*Block, er
 		return nil, err
 	}
 
-	return &block, nil
+	return blockFromGenerated(block)
 }
 
 func (c *Client) GetLatestHeader(ctx context.Context) (*BlockHeader, error) {
@@ -157,7 +172,7 @@ func (c *Client) GetLatestHeader(ctx context.Context) (*BlockHeader, error) {
 		return nil, err
 	}
 
-	return &header, nil
+	return headerFromGenerated(header)
 }
 
 func (c *Client) GetHeaderByHeight(ctx context.Context, height uint) (*BlockHeader, error) {
@@ -176,16 +191,21 @@ func (c *Client) GetHeaderByHeight(ctx context.Context, height uint) (*BlockHead
 		return nil, err
 	}
 
-	return &header, nil
+	return headerFromGenerated(header)
 }
 
-func (c *Client) GetHeaders(ctx context.Context, opts *GetHeadersOptions) ([]BlockHeader, error) {
+func (c *Client) GetHeaders(ctx context.Context, opts *GetHeadersOptions) ([]*BlockHeader, error) {
 	resp, err := c.client.GetHeadersWithResponse(ctx, getHeadersParams(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get headers: %w", err)
 	}
 
-	return expectOK("get headers", resp.StatusCode(), resp.Body, resp.JSON200)
+	headers, err := expectOK("get headers", resp.StatusCode(), resp.Body, resp.JSON200)
+	if err != nil {
+		return nil, err
+	}
+
+	return headersFromGenerated(headers)
 }
 
 func normalizeServerURL(baseURL string) string {

--- a/sdk/go/v1beta/client_test.go.tmpl
+++ b/sdk/go/v1beta/client_test.go.tmpl
@@ -7,27 +7,29 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/yago-123/chainnet-sdk-go/v1beta/generated"
 )
 
 func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smoke test is intentionally linear
-	utxos := []UTXO{
+	utxos := []generated.UTXO{
 		{
 			Txid: "74782d6964",
 			Vout: 1,
-			Output: TxOutput{
+			Output: generated.TxOutput{
 				Amount:       10,
 				ScriptPubKey: "script",
 				PubKey:       "pub-key",
 			},
 		},
 	}
-	txs := []Transaction{
+	txs := []generated.Transaction{
 		{
 			Id: "74782d6964",
-			Vin: []TxInput{
+			Vin: []generated.TxInput{
 				{Txid: "74782d6964", Vout: 1, ScriptSig: "script-sig", PubKey: "pub-key"},
 			},
-			Vout: []TxOutput{
+			Vout: []generated.TxOutput{
 				{Amount: 10, ScriptPubKey: "script", PubKey: "pub-key"},
 			},
 		},
@@ -47,7 +49,7 @@ func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smo
 			t.Fatal(err)
 		}
 
-		var tx Transaction
+		var tx generated.Transaction
 		if err := json.Unmarshal(body, &tx); err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +73,7 @@ func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smo
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(gotUTXOs) != 1 || gotUTXOs[0].Vout != 1 {
+	if len(gotUTXOs) != 1 || gotUTXOs[0].OutIdx != 1 {
 		t.Fatalf("unexpected UTXOs: %#v", gotUTXOs)
 	}
 
@@ -79,7 +81,7 @@ func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smo
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(gotTxs) != 1 || gotTxs[0].Id != "74782d6964" {
+	if len(gotTxs) != 1 || string(gotTxs[0].ID) != "tx-id" {
 		t.Fatalf("unexpected transactions: %#v", gotTxs)
 	}
 
@@ -91,7 +93,15 @@ func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smo
 		t.Fatal("expected address to be active")
 	}
 
-	if sendErr := client.SendTransaction(context.Background(), txs[0]); sendErr != nil {
+	if sendErr := client.SendTransaction(context.Background(), Transaction{
+		ID: []byte("tx-id"),
+		Vin: []TxInput{
+			{Txid: []byte("tx-id"), Vout: 1, ScriptSig: "script-sig", PubKey: "pub-key"},
+		},
+		Vout: []TxOutput{
+			{Amount: 10, ScriptPubKey: "script", PubKey: "pub-key"},
+		},
+	}); sendErr != nil {
 		t.Fatal(sendErr)
 	}
 
@@ -99,13 +109,13 @@ func TestClientWalletEndpoints(t *testing.T) { //nolint:gocognit // endpoint smo
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tx.Id != "74782d6964" {
-		t.Fatalf("tx ID = %q, want %q", tx.Id, "74782d6964")
+	if string(tx.ID) != "tx-id" {
+		t.Fatalf("tx ID = %q, want %q", tx.ID, "tx-id")
 	}
 }
 
 func TestClientChainEndpoints(t *testing.T) { //nolint:gocognit // endpoint smoke test is intentionally linear
-	header := BlockHeader{
+	header := generated.BlockHeader{
 		Version:       "7631",
 		PrevBlockHash: "70726576696f75732d626c6f636b2d68617368",
 		MerkleRoot:    "6d65726b6c652d726f6f74",
@@ -114,9 +124,9 @@ func TestClientChainEndpoints(t *testing.T) { //nolint:gocognit // endpoint smok
 		Target:        1,
 		Nonce:         42,
 	}
-	block := Block{
+	block := generated.Block{
 		Header:       header,
-		Transactions: []Transaction{},
+		Transactions: []generated.Transaction{},
 		Hash:         "626c6f636b2d68617368",
 	}
 	tip := ChainTip{
@@ -138,7 +148,7 @@ func TestClientChainEndpoints(t *testing.T) { //nolint:gocognit // endpoint smok
 		if got, want := r.URL.Query().Get("order"), string(HeaderOrderOldestFirst); got != want {
 			t.Fatalf("order = %q, want %q", got, want)
 		}
-		writeJSON(t, []BlockHeader{header})(w, r)
+		writeJSON(t, []generated.BlockHeader{header})(w, r)
 	})
 
 	server := httptest.NewServer(mux)
@@ -161,16 +171,16 @@ func TestClientChainEndpoints(t *testing.T) { //nolint:gocognit // endpoint smok
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotBlock.Hash != "626c6f636b2d68617368" {
-		t.Fatalf("latest block hash = %q, want %q", gotBlock.Hash, "626c6f636b2d68617368")
+	if string(gotBlock.Hash) != "block-hash" {
+		t.Fatalf("latest block hash = %q, want %q", gotBlock.Hash, "block-hash")
 	}
 
 	gotBlock, err = client.GetBlockByHash(context.Background(), []byte("block-hash"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotBlock.Hash != "626c6f636b2d68617368" {
-		t.Fatalf("block hash = %q, want %q", gotBlock.Hash, "626c6f636b2d68617368")
+	if string(gotBlock.Hash) != "block-hash" {
+		t.Fatalf("block hash = %q, want %q", gotBlock.Hash, "block-hash")
 	}
 
 	gotHeader, err := client.GetLatestHeader(context.Background())

--- a/sdk/go/v1beta/convert.go.tmpl
+++ b/sdk/go/v1beta/convert.go.tmpl
@@ -11,6 +11,268 @@ func encodeHex(value []byte) string {
 	return hex.EncodeToString(value)
 }
 
+func blockFromGenerated(block generated.Block) (*Block, error) {
+	header, err := headerFromGenerated(block.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	transactions, err := transactionsFromGenerated(block.Transactions)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, err := decodeHexField("hash", block.Hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Block{
+		Header:       header,
+		Transactions: transactions,
+		Hash:         hash,
+	}, nil
+}
+
+func headerFromGenerated(header generated.BlockHeader) (*BlockHeader, error) {
+	version, err := decodeHexField("version", header.Version)
+	if err != nil {
+		return nil, err
+	}
+	prevBlockHash, err := decodeHexField("prev_block_hash", header.PrevBlockHash)
+	if err != nil {
+		return nil, err
+	}
+	merkleRoot, err := decodeHexField("merkle_root", header.MerkleRoot)
+	if err != nil {
+		return nil, err
+	}
+	height, err := intToUint("height", header.Height)
+	if err != nil {
+		return nil, err
+	}
+	target, err := intToUint("target", header.Target)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := intToUint("nonce", header.Nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BlockHeader{
+		Version:       version,
+		PrevBlockHash: prevBlockHash,
+		MerkleRoot:    merkleRoot,
+		Height:        height,
+		Timestamp:     header.Timestamp,
+		Target:        target,
+		Nonce:         nonce,
+	}, nil
+}
+
+func headersFromGenerated(headers []generated.BlockHeader) ([]*BlockHeader, error) {
+	ret := make([]*BlockHeader, 0, len(headers))
+	for _, header := range headers {
+		converted, err := headerFromGenerated(header)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, converted)
+	}
+
+	return ret, nil
+}
+
+func transactionToGenerated(tx Transaction) (generated.Transaction, error) {
+	inputs, err := txInputsToGenerated(tx.Vin)
+	if err != nil {
+		return generated.Transaction{}, err
+	}
+	outputs, err := txOutputsToGenerated(tx.Vout)
+	if err != nil {
+		return generated.Transaction{}, err
+	}
+
+	return generated.Transaction{
+		Id:   encodeHex(tx.ID),
+		Vin:  inputs,
+		Vout: outputs,
+	}, nil
+}
+
+func transactionFromGenerated(tx generated.Transaction) (*Transaction, error) {
+	id, err := decodeHexField("id", tx.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	inputs, err := txInputsFromGenerated(tx.Vin)
+	if err != nil {
+		return nil, err
+	}
+
+	outputs, err := txOutputsFromGenerated(tx.Vout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Transaction{
+		ID:   id,
+		Vin:  inputs,
+		Vout: outputs,
+	}, nil
+}
+
+func transactionsFromGenerated(txs []generated.Transaction) ([]*Transaction, error) {
+	ret := make([]*Transaction, 0, len(txs))
+	for _, tx := range txs {
+		converted, err := transactionFromGenerated(tx)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, converted)
+	}
+
+	return ret, nil
+}
+
+func txInputsToGenerated(inputs []TxInput) ([]generated.TxInput, error) {
+	ret := make([]generated.TxInput, 0, len(inputs))
+	for _, input := range inputs {
+		vout, err := uintToInt("vout", input.Vout)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, generated.TxInput{
+			Txid:      encodeHex(input.Txid),
+			Vout:      vout,
+			ScriptSig: input.ScriptSig,
+			PubKey:    input.PubKey,
+		})
+	}
+
+	return ret, nil
+}
+
+func txInputsFromGenerated(inputs []generated.TxInput) ([]TxInput, error) {
+	ret := make([]TxInput, 0, len(inputs))
+	for _, input := range inputs {
+		txID, err := decodeHexField("txid", input.Txid)
+		if err != nil {
+			return nil, err
+		}
+		vout, err := intToUint("vout", input.Vout)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, TxInput{
+			Txid:      txID,
+			Vout:      vout,
+			ScriptSig: input.ScriptSig,
+			PubKey:    input.PubKey,
+		})
+	}
+
+	return ret, nil
+}
+
+func txOutputsToGenerated(outputs []TxOutput) ([]generated.TxOutput, error) {
+	ret := make([]generated.TxOutput, 0, len(outputs))
+	for _, output := range outputs {
+		amount, err := uintToInt("amount", output.Amount)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, generated.TxOutput{
+			Amount:       amount,
+			ScriptPubKey: output.ScriptPubKey,
+			PubKey:       output.PubKey,
+		})
+	}
+
+	return ret, nil
+}
+
+func txOutputsFromGenerated(outputs []generated.TxOutput) ([]TxOutput, error) {
+	ret := make([]TxOutput, 0, len(outputs))
+	for _, output := range outputs {
+		amount, err := intToUint("amount", output.Amount)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, TxOutput{
+			Amount:       amount,
+			ScriptPubKey: output.ScriptPubKey,
+			PubKey:       output.PubKey,
+		})
+	}
+
+	return ret, nil
+}
+
+func utxosFromGenerated(utxos []generated.UTXO) ([]UTXO, error) {
+	ret := make([]UTXO, 0, len(utxos))
+	for _, utxo := range utxos {
+		txID, err := decodeHexField("txid", utxo.Txid)
+		if err != nil {
+			return nil, err
+		}
+		outIdx, err := intToUint("vout", utxo.Vout)
+		if err != nil {
+			return nil, err
+		}
+		output, err := txOutputFromGenerated(utxo.Output)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, UTXO{
+			TxID:   txID,
+			OutIdx: outIdx,
+			Output: output,
+		})
+	}
+
+	return ret, nil
+}
+
+func txOutputFromGenerated(output generated.TxOutput) (TxOutput, error) {
+	amount, err := intToUint("amount", output.Amount)
+	if err != nil {
+		return TxOutput{}, err
+	}
+
+	return TxOutput{
+		Amount:       amount,
+		ScriptPubKey: output.ScriptPubKey,
+		PubKey:       output.PubKey,
+	}, nil
+}
+
+func decodeHexField(field string, value string) ([]byte, error) {
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding %s: %w", field, err)
+	}
+
+	return decoded, nil
+}
+
+func intToUint(field string, value int) (uint, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", field)
+	}
+
+	return uint(value), nil
+}
+
 func uintToInt(field string, value uint) (int, error) {
 	maxInt := ^uint(0) >> 1
 	if value > maxInt {

--- a/sdk/go/v1beta/types.go.tmpl
+++ b/sdk/go/v1beta/types.go.tmpl
@@ -2,14 +2,53 @@ package v1beta
 
 import "github.com/yago-123/chainnet-sdk-go/v1beta/generated"
 
-type Block = generated.Block
-type BlockHeader = generated.BlockHeader
+type Block struct {
+	Header       *BlockHeader
+	Transactions []*Transaction
+	Hash         []byte
+}
+
+type BlockHeader struct {
+	Version       []byte
+	PrevBlockHash []byte
+	MerkleRoot    []byte
+	Height        uint
+	Timestamp     int64
+	Target        uint
+	Nonce         uint
+}
+
 type ChainTip = generated.ChainTip
 type ErrorResponse = generated.ErrorResponse
-type Transaction = generated.Transaction
-type TxInput = generated.TxInput
-type TxOutput = generated.TxOutput
-type UTXO = generated.UTXO
+
+type Transaction struct {
+	ID   []byte
+	Vin  []TxInput
+	Vout []TxOutput
+}
+
+type TxInput struct {
+	Txid      []byte
+	Vout      uint
+	ScriptSig string
+	PubKey    string
+}
+
+type TxOutput struct {
+	Amount       uint
+	ScriptPubKey string
+	PubKey       string
+}
+
+type UTXO struct {
+	TxID   []byte
+	OutIdx uint
+	Output TxOutput
+}
+
+func (utxo UTXO) Amount() uint {
+	return utxo.Output.Amount
+}
 
 type HeaderOrder = generated.GetHeadersParamsOrder
 

--- a/tests/e2e/sdk_e2e_test.go
+++ b/tests/e2e/sdk_e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	sdkv1beta "github.com/yago-123/chainnet-sdk-go/v1beta"
 	"github.com/yago-123/chainnet/config"
 	blockchain "github.com/yago-123/chainnet/pkg/chain"
 	"github.com/yago-123/chainnet/pkg/chain/explorer"
@@ -31,10 +32,10 @@ import (
 	"github.com/yago-123/chainnet/pkg/observer"
 	"github.com/yago-123/chainnet/pkg/script"
 	"github.com/yago-123/chainnet/pkg/script/interpreter"
-	sdkv1beta "github.com/yago-123/chainnet/pkg/sdk/v1beta"
 	"github.com/yago-123/chainnet/pkg/storage"
 	"github.com/yago-123/chainnet/pkg/util"
 	"github.com/yago-123/chainnet/pkg/utxoset"
+	common "github.com/yago-123/chainnet/pkg/wallet"
 )
 
 const (
@@ -118,19 +119,19 @@ func TestSDK_SubmitTransactionsMineBlockAndReadBack(t *testing.T) {
 	tx1 := newSignedSpendTx(t, signer, hasher, pubKey, privKey, fundingBlock1.Transactions[0], 0, []byte("sdk-e2e-recipient-1"), 10, 1)
 	tx2 := newSignedSpendTx(t, signer, hasher, pubKey, privKey, fundingBlock2.Transactions[0], 0, []byte("sdk-e2e-recipient-2"), 20, 1)
 
-	require.NoError(t, client.SendTransaction(ctx, *tx1))
-	require.NoError(t, client.SendTransaction(ctx, *tx2))
+	require.NoError(t, client.SendTransaction(ctx, common.KernelTransactionToSDK(*tx1)))
+	require.NoError(t, client.SendTransaction(ctx, common.KernelTransactionToSDK(*tx2)))
 
 	minedBlock, err := blockMiner.MineBlock()
 	require.NoError(t, err)
-	require.True(t, containsTxID(minedBlock, tx1.ID), "mined block does not contain tx1")
-	require.True(t, containsTxID(minedBlock, tx2.ID), "mined block does not contain tx2")
+	require.True(t, containsKernelTxID(minedBlock, tx1.ID), "mined block does not contain tx1")
+	require.True(t, containsKernelTxID(minedBlock, tx2.ID), "mined block does not contain tx2")
 
 	latestBlock, err := client.GetLatestBlock(ctx)
 	require.NoError(t, err)
 	require.Equal(t, minedBlock.Hash, latestBlock.Hash)
-	require.True(t, containsTxID(latestBlock, tx1.ID), "latest block does not contain tx1")
-	require.True(t, containsTxID(latestBlock, tx2.ID), "latest block does not contain tx2")
+	require.True(t, containsSDKTxID(latestBlock, tx1.ID), "latest block does not contain tx1")
+	require.True(t, containsSDKTxID(latestBlock, tx2.ID), "latest block does not contain tx2")
 
 	blockByHash, err := client.GetBlockByHash(ctx, minedBlock.Hash)
 	require.NoError(t, err)
@@ -249,7 +250,17 @@ func (testSignature) Verify(signature []byte, payload []byte, _ []byte) (bool, e
 	return bytes.Equal(signature, expected), nil
 }
 
-func containsTxID(block *kernel.Block, txID []byte) bool {
+func containsKernelTxID(block *kernel.Block, txID []byte) bool {
+	for _, tx := range block.Transactions {
+		if bytes.Equal(tx.ID, txID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsSDKTxID(block *sdkv1beta.Block, txID []byte) bool {
 	for _, tx := range block.Transactions {
 		if bytes.Equal(tx.ID, txID) {
 			return true


### PR DESCRIPTION
In order to start decoupling from the local SDK generation we moved `nespv`, `wallet`, `accounts` and the bot to the `v0.2.0-rc1` SDK `chainnet-sdk-go`. 

Among other things we moved all imports, implemented some 